### PR TITLE
Disable running of the rspec system tests

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -7,9 +7,9 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
+          cache: "yarn"
       - name: Install Node packages
         run: yarn install
       # Add or replace database setup steps here
@@ -47,7 +47,7 @@ jobs:
         run: bin/rails db:schema:load
       # Add or replace test runners here
       - name: Run rspec
-        run: bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"
+        run: bundle exec rspec
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--exclude-pattern spec/system/**/*_spec.rb

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Or use [overmind](https://github.com/DarthSim/overmind): `overmind s -N -f Procf
 
 Selenium Grid becomes available at http://localhost:4444/ui
 
+**Note:** For the moment system specs are configured not to run from the [.rspec config file.](.rspec).
+
 ## Versioning & Deployment
 
 1. Update the [changelog](CHANGELOG.md)


### PR DESCRIPTION
For the moment running of system tests has been disabled by the addition of the `--exclude-pattern` parameter to the `.rspec` configuration file.

This is so that this parameter shouldn't be specified on each run of the rspec command.