### PR TITLE
Fix tags_query_spec.rb flakiness

### DIFF
--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "#{Faker::Lorem.word.downcase}-#{n}" }
 
     trait :with_prefix do
-      name { "prefix-#{Faker::Lorem.word.downcase}" }
+      sequence(:name) { |n| "prefix-#{Faker::Lorem.word.downcase}-#{n}" }
     end
   end
 end


### PR DESCRIPTION
Occasionally  spec/requests/graphql/queries/tags_query_spec.rb fails on line 129 with the following error:

```
1) tags Query with query parameter for user tags returns filtered tags
     Failure/Error: expect(data_dig(response, 'tags').size).to eq(3)

       expected: 3
            got: 2

       (compared using ==)
     # ./spec/requests/graphql/queries/tags_query_spec.rb:129:in 'block (3 levels) in <top (required)>'
```

Hopefully the culprit was the factory which didn't generate unique tag names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test factory to generate unique identifiers, improving test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->